### PR TITLE
Handle browser back button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,11 @@
     </noscript>
     <div id="root"></div>
     <script src="main.js"></script>
-
+    <script>
+      window.onhashchange = function(e) {
+        if(location.hash === "#/")
+          location.reload()
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
The idea is when you go direct to ICO page, the app just loaded the current ICO data in the state.
the solution was to control this button event, and force it to reload the page in this case. 