### PR TITLE
Improve decoding performance

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -437,6 +437,7 @@ export default {
         },
         status: async icoContract => 'successful', // could return isFueled
       },
+      boostDecoding: true,
       matrix: {
         q1: { answer: true },
         q2: { answer: true },

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,6 +77,96 @@ export const getValueOrNotAvailable = (props, input) => props && props[input] ? 
 
 export const trimString = value => value.replace(/ /g, '');
 
+function boostedDecoding(icoContract, address, event, eventName, blockRange) {
+  return new Promise((resolve, reject) => {
+    const eventAbi = icoContract.abi.filter(json => json.type === 'event').filter(json => json.name === eventName)[0];
+    const solidityEvent = new SolidityEvent(null, eventAbi, address);
+    const solidityEventEncoded = solidityEvent.encode(event.customArgs || {}, {
+      fromBlock: blockRange[0],
+      toBlock: blockRange[1],
+    });
+    const fastDecodeEvent = fastEventDecoder(solidityEvent);
+
+    jQuery.ajax({
+      type: 'POST',
+      url: config.rpcHost,
+      Accept: 'application/json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        id: 1497353430507566, // keep this ID to make cache work
+        jsonrpc: '2.0',
+        params: [{
+          fromBlock: solidityEventEncoded.fromBlock,
+          toBlock: solidityEventEncoded.toBlock,
+          address,
+          topics: solidityEventEncoded.topics,
+        }],
+        method: 'eth_getLogsDetails',
+      }),
+      success: (e) => {
+        if (e.error) {
+          console.log(e);
+          reject('SHOW_MODAL_ERROR', `Error when getting logs ${e.error.message}`);
+        } else {
+          const res = e.result;
+          console.log(`formatting ${res.length} log entries`);
+          const logsFormat = res.map(log => fastDecodeEvent(log));
+          console.log('log entries formatted');
+          resolve(logsFormat);
+        }
+      },
+      error: (status) => {
+        reject('SHOW_MODAL_ERROR', `Error ${status}`);
+      },
+      dataType: 'json',
+    });
+  })
+}
+
+function standardDecoding(icoContract, address, event, eventName, blockRange) {
+  return new Promise((resolve, reject) => {
+    const filter = icoContract[eventName](event.customArgs || {}, {
+      fromBlock: blockRange[0],
+      toBlock: blockRange[1],
+    });
+    filter.stopWatching(() => {});
+
+    jQuery.ajax({
+      type: 'POST',
+      url: config.rpcHost,
+      Accept: 'application/json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        id: 1497353430507566, // keep this ID to make cache work
+        jsonrpc: '2.0',
+        params: [{
+          fromBlock: filter.options.fromBlock,
+          toBlock: filter.options.toBlock,
+          address,
+          topics: filter.options.topics,
+        }],
+        method: 'eth_getLogsDetails',
+      }),
+      success: (e) => {
+        if (e.error) {
+          console.log(e);
+          reject(`Error when getting logs ${e.error.message}`);
+        } else {
+          const res = e.result;
+          console.log(`formatting ${res.length} log entries`);
+          const logsFormat = res.map(log => filter.formatter ? filter.formatter(log) : log);
+          console.log('log entries formatted');
+          resolve(logsFormat);
+        }
+      },
+      error: (status) => {
+        reject(`Error ${status}`);
+      },
+      dataType: 'json',
+    });
+  });
+}
+
 export const getICOLogs = (blockRange, icoConfig, icoContract, callback) => {
   console.log(`Start scanning for block range ${blockRange}`, icoContract.address);
   /* if (typeof localStorage !== 'undefined' && localStorage.getItem(address)) {
@@ -87,46 +177,13 @@ export const getICOLogs = (blockRange, icoConfig, icoContract, callback) => {
   const eventName = blockRange[2];
   const event = icoConfig.events[eventName];
 
-  const eventAbi = icoContract.abi.filter(json => json.type === 'event').filter(json => json.name === eventName)[0];
-  const solidityEvent = new SolidityEvent(null, eventAbi, address);
-  const solidityEventEncoded = solidityEvent.encode(event.customArgs || {}, {
-    fromBlock: blockRange[0],
-    toBlock: blockRange[1],
-  });
-  const fastDecodeEvent = fastEventDecoder(solidityEvent);
 
-  jQuery.ajax({
-    type: 'POST',
-    url: config.rpcHost,
-    Accept: 'application/json',
-    contentType: 'application/json',
-    data: JSON.stringify({
-      id: 1497353430507566, // keep this ID to make cache work
-      jsonrpc: '2.0',
-      params: [{
-        fromBlock: solidityEventEncoded.fromBlock,
-        toBlock: solidityEventEncoded.toBlock,
-        address,
-        topics: solidityEventEncoded.topics,
-      }],
-      method: 'eth_getLogsDetails',
-    }),
-    success: (e) => {
-      if (e.error) {
-        console.log(e);
-        callback('SHOW_MODAL_ERROR', `Error when getting logs ${e.error.message}`);
-      } else {
-        const res = e.result;
-        console.log(`formatting ${res.length} log entries`);
-        const logsFormat = res.map(log => fastDecodeEvent(log));
-        console.log('log entries formatted');
-        callback(null, logsFormat);
-      }
-    },
-    error: (status) => {
-      callback('SHOW_MODAL_ERROR', `Error ${status}`);
-    },
-    dataType: 'json',
+  const logsPromise = icoConfig.boostDecoding? boostedDecoding : standardDecoding;
+
+  logsPromise(icoContract, address, event, eventName, blockRange).then((res) => {
+    callback(null, res);
+  }).catch((err) => {
+    callback('SHOW_MODAL_ERROR', err);
   });
 };
 

--- a/src/utils/fastDecode.js
+++ b/src/utils/fastDecode.js
@@ -1,0 +1,60 @@
+export function fastDecodeUint(uint) {
+  return parseInt(uint, 16);
+}
+
+export function fastDecodeAddress(value) {
+  return '0x' + value.slice(value.length - 40, value.length);
+}
+
+export const fastDecoders = {
+  address: fastDecodeAddress,
+  uint256: fastDecodeUint,
+}
+
+export function fastDecodeType(typeName, value) {
+  const fastDecoder = fastDecoders[typeName];
+  if (!fastDecoder) {
+    throw new Error(`No decode for type ${typeName}`);
+  }
+
+  return fastDecoders[typeName](value);
+}
+
+export function fastEventDecoder(eventDescription) {
+  const indexedTypes = eventDescription.types(true);
+  const notIndexedTypes = eventDescription.types(false);
+
+  if (notIndexedTypes.length != 1) {
+    throw new Error("Fast decode supports only 1 not indexed param");
+  }
+
+  return (rawEvent) => {
+    const argTopics = eventDescription._anonymous ? rawEvent.topics : rawEvent.topics.slice(1);
+    const indexedData = argTopics.map(topics => topics.slice(2));
+    const indexedParams = indexedTypes.map((typeName, index) => fastDecodeType(typeName, indexedData[index]));
+
+    const notIndexedData = rawEvent.data.slice(2);
+    const notIndexedParams = notIndexedTypes.map((typeName) => fastDecodeType(typeName, notIndexedData));
+
+    const args = eventDescription._params.reduce((acc, current) => {
+      acc[current.name] = current.indexed ? indexedParams.shift() : notIndexedParams.shift();
+      return acc;
+    }, {});
+
+
+    return {
+      event: eventDescription.displayName(),
+      address: rawEvent.address,
+      blockHash: rawEvent.blockHash,
+      blockNumber: fastDecodeUint(rawEvent.blockNumber),
+      logIndex: fastDecodeUint(rawEvent.logIndex),
+      timestamp: rawEvent.timestamp,
+      transactionHash: rawEvent.transactionHash,
+      transactionIndex: fastDecodeUint(rawEvent.transactionIndex),
+      transactionLogIndex: rawEvent.transactionLogIndex,
+      type: rawEvent.type,
+      value: rawEvent.value,
+      args,
+    };
+  }
+}


### PR DESCRIPTION
It's enabled only on one ICO now because it requires writing more code to decode various types of events.
Before, decoding took ~1800ms for DAO token page, now it's around ~200ms (9x speedup).